### PR TITLE
Empty site link alert added and https prefix issue examined

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,19 +120,21 @@
                                 <label class="col-sm-2 control-label" for="inputEmail3" style="color: white;font-family: 'Product Sans'">Card Label</label>
                                 <div class="col-sm-10" style="padding-bottom: 15px;padding-top: 10px;">
                                     <input type="site" class="form-control" id="inputSiteName" placeholder="My personal website" autofocus>
+                                    <p style="display: none; margin-top: 4px; margin-left: 3px;" id="erro"></p>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <label class="col-sm-2 control-label" for="inputPassword3" style="color: white;font-family: 'Product Sans'">Link</label>
                                 <div class="col-sm-10" style="padding-top: 10px;">
                                     <input type="site_link" class="form-control" id="inputSiteLink" placeholder="https://daksh.eu.org" onblur="checkURL(this)">
+                                    <p style="display: none; margin-top: 4px; margin-left: 3px;" id="error"></p>
                                 </div>
                             </div>
                         </form>
                     </div>
 
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal" id="modalClose">Close</button>
                         <button type="submit" class="btn btn-primary" id="addSiteButton">Add Site</button>
                     </div>
                 </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -251,7 +251,7 @@ $(document).ready(function() {
     $('#myModal').modal('toggle');
     }
     if(flaglink===1&&flagname!=1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;>ERROR : Incorrect Website URL</p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>ERROR : Incorrect Website URL</p>";
       document.getElementById("error").style.display="block";
       document.getElementById("erro").innerHTML="";
       document.getElementById("erro").style.display="hidden";
@@ -263,9 +263,9 @@ $(document).ready(function() {
       document.getElementById("error").style.display="hidden";
     }
     else if(flagname==1&&flaglink===1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;'><b>ERROR : Incorrect Website URL</b></p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>ERROR : Incorrect Website URL</p>";
       document.getElementById("error").style.display="block";
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'><b>ERROR : No Label provided</b></p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>ERROR : No Label provided</p>";
       document.getElementById("erro").style.display="block";
     }
     event.preventDefault();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -257,7 +257,7 @@ $(document).ready(function() {
       document.getElementById("erro").style.display="hidden";
     }
     if(flagname===1&&flaglink!=1){
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'><b>ERROR : No Label provided</b></p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>ERROR : No Label provided</p>";
       document.getElementById("erro").style.display="block";
       document.getElementById("error").innerHTML="";
       document.getElementById("error").style.display="hidden";

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -267,21 +267,21 @@ $(document).ready(function() {
     $('#myModal').modal('toggle');
     }
     if(flaglink===1&&flagname!=1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;font-family:Product Sans'>ERROR : Incorrect Website URL</p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;font-family:Product Sans'>ERROR: Incorrect website URL</p>";
       document.getElementById("error").style.display="block";
       document.getElementById("erro").innerHTML="";
       document.getElementById("erro").style.display="hidden";
     }
     if(flagname===1&&flaglink!=1){
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR : No Label provided</p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR: No label provided</p>";
       document.getElementById("erro").style.display="block";
       document.getElementById("error").innerHTML="";
       document.getElementById("error").style.display="hidden";
     }
     else if(flagname==1&&flaglink===1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR : Incorrect Website URL</p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR: Incorrect website URL</p>";
       document.getElementById("error").style.display="block";
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR : No Label provided</p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR: No label provided</p>";
       document.getElementById("erro").style.display="block";
     }
     event.preventDefault();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -218,19 +218,21 @@ $(document).ready(function() {
 
     $("#addSiteButton").click(function(event) {
 
-
-
     $('#myModal').modal('toggle');
     var site = $("form input[type='site']").val()
     var site_link = $("form input[type='site_link']").val()
-    if (!~site_link.indexOf("http")) {
-        site_link = "http://" + site_link;
+    var flag=0;
+    if(site_link===""){
+      flag=1;
+      swal("No site link found !!")
     }
-
-    
-
+    else if (~!site_link.indexOf("http")) {
+        site_link = "http://"+site_link;
+    }
+    if(flag!=1){
     Lockr.sadd('customSites', [site, site_link]);
     addGridElement(site, site_link);
+    }
 
     
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -251,21 +251,21 @@ $(document).ready(function() {
     $('#myModal').modal('toggle');
     }
     if(flaglink===1&&flagname!=1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>Wrong Website URL</p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;>ERROR : Incorrect Website URL</p>";
       document.getElementById("error").style.display="block";
       document.getElementById("erro").innerHTML="";
       document.getElementById("erro").style.display="hidden";
     }
     if(flagname===1&&flaglink!=1){
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>No Label provided</p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'><b>ERROR : No Label provided</b></p>";
       document.getElementById("erro").style.display="block";
       document.getElementById("error").innerHTML="";
       document.getElementById("error").style.display="hidden";
     }
     else if(flagname==1&&flaglink===1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>Wrong Website URL</p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;'><b>ERROR : Incorrect Website URL</b></p>";
       document.getElementById("error").style.display="block";
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>No Label provided</p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'><b>ERROR : No Label provided</b></p>";
       document.getElementById("erro").style.display="block";
     }
     event.preventDefault();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -224,7 +224,16 @@ $(document).ready(function() {
     var flag=0;
     if(site_link.trim()===""){
       flag=1;
-      swal("No site link found !!")
+      swal({
+        title: '<h4 style="color:red;">Incorrect Website URL</h4>',
+        html:
+          '<h4 style="color:red;">Incorrect Website URL</h4> ',
+          type: "warning",
+            
+      },
+      function(){
+        $('#myModal').modal('toggle');
+  })
     }
     else if (~!site_link.indexOf("http")) {
         site_link = "http://"+site_link;
@@ -234,9 +243,7 @@ $(document).ready(function() {
     addGridElement(site, site_link);
     }
 
-    
-
-    event.preventDefault();
+   event.preventDefault();
 });
 
     $('.content').on('click', '.delete', function() {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -215,35 +215,60 @@ $(document).ready(function() {
             $('#btn_end').addClass("clicked");
         };
     };
-
+    $("#modalClose").click(function(event) {
+      document.getElementById("error").innerHTML="";
+    document.getElementById("error").style.display="hidden";
+    document.getElementById("erro").innerHTML="";
+    document.getElementById("erro").style.display="hidden";
+    document.getElementById("inputSiteLink").value="";
+    document.getElementById("inputSiteName").value="";
+      
+  });
+    
     $("#addSiteButton").click(function(event) {
-
-    $('#myModal').modal('toggle');
+      
     var site = $("form input[type='site']").val()
     var site_link = $("form input[type='site_link']").val()
-    var flag=0;
+    var flaglink=0,flagname=0;
     if(site_link.trim()===""){
-      flag=1;
-      swal({
-        title: '<h4 style="color:red;">Incorrect Website URL</h4>',
-        html:
-          '<h4 style="color:red;">Incorrect Website URL</h4> ',
-          type: "warning",
-            
-      },
-      function(){
-        $('#myModal').modal('toggle');
-  })
+      flaglink=1;
+    }
+    if(site.trim()===""){
+      flagname=1;
     }
     else if (~!site_link.indexOf("http")) {
         site_link = "http://"+site_link;
     }
-    if(flag!=1){
+    if(flaglink!=1&&flagname!=1){
     Lockr.sadd('customSites', [site, site_link]);
     addGridElement(site, site_link);
+    document.getElementById("error").innerHTML="";
+    document.getElementById("error").style.display="hidden";
+    document.getElementById("erro").innerHTML="";
+    document.getElementById("erro").style.display="hidden";
+    document.getElementById("inputSiteLink").value="";
+    document.getElementById("inputSiteName").value="";
+    $('#myModal').modal('toggle');
     }
-
-   event.preventDefault();
+    if(flaglink===1&&flagname!=1){
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>Wrong Website URL</p>";
+      document.getElementById("error").style.display="block";
+      document.getElementById("erro").innerHTML="";
+      document.getElementById("erro").style.display="hidden";
+    }
+    if(flagname===1&&flaglink!=1){
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>No Label provided</p>";
+      document.getElementById("erro").style.display="block";
+      document.getElementById("error").innerHTML="";
+      document.getElementById("error").style.display="hidden";
+    }
+    else if(flagname==1&&flaglink===1){
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>Wrong Website URL</p>";
+      document.getElementById("error").style.display="block";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>No Label provided</p>";
+      document.getElementById("erro").style.display="block";
+    }
+    event.preventDefault();
 });
 
     $('.content').on('click', '.delete', function() {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -222,7 +222,7 @@ $(document).ready(function() {
     var site = $("form input[type='site']").val()
     var site_link = $("form input[type='site_link']").val()
     var flag=0;
-    if(site_link===""){
+    if(site_link.trim()===""){
       flag=1;
       swal("No site link found !!")
     }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -251,21 +251,21 @@ $(document).ready(function() {
     $('#myModal').modal('toggle');
     }
     if(flaglink===1&&flagname!=1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>ERROR : Incorrect Website URL</p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;font-family:Product Sans'>ERROR : Incorrect Website URL</p>";
       document.getElementById("error").style.display="block";
       document.getElementById("erro").innerHTML="";
       document.getElementById("erro").style.display="hidden";
     }
     if(flagname===1&&flaglink!=1){
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>ERROR : No Label provided</p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR : No Label provided</p>";
       document.getElementById("erro").style.display="block";
       document.getElementById("error").innerHTML="";
       document.getElementById("error").style.display="hidden";
     }
     else if(flagname==1&&flaglink===1){
-      document.getElementById("error").innerHTML="<p style='color:#FF0000;'>ERROR : Incorrect Website URL</p>";
+      document.getElementById("error").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR : Incorrect Website URL</p>";
       document.getElementById("error").style.display="block";
-      document.getElementById("erro").innerHTML="<p style='color:#FF0000;'>ERROR : No Label provided</p>";
+      document.getElementById("erro").innerHTML="<p style='color:#FF0000;font-family:Product Sans''>ERROR : No Label provided</p>";
       document.getElementById("erro").style.display="block";
     }
     event.preventDefault();


### PR DESCRIPTION
### 🛠️ Fixes Issue #19 

### 👨‍💻 Changes proposed

1. Used swal to give alert for an empty site link and then not add the site to the grid.
2. Examined the http prefix issue and on closer examination found, that URL was not showing http:// because browsers hide the prefix but in reality http:// prefix is working totally fine.
3. **Whitespaces can be detected too and alert is triggered.**

### ✔️ Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

### 📄 Note to reviewers


## 📷 Screenshots

![Screenshot 2022-03-02 010430](https://user-images.githubusercontent.com/68824237/156236325-f59ab0e0-9a36-4391-b7f3-767170152885.png)
![Screenshot 2022-03-02 010449](https://user-images.githubusercontent.com/68824237/156236348-edef5b8d-eabe-4106-9833-2bf53bd71cd9.png)

